### PR TITLE
fix:插件与vscode版本不兼容，改为最低1.64（2022年第一个版本）

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "publisher": "ddiu8081",
   "engines": {
-    "vscode": "^1.72.0"
+    "vscode": "^1.64.0"
   },
   "categories": [
     "Themes"


### PR DESCRIPTION
安装插件时提示不兼容，跑去百度发现应该是插件`package.json`设置的版本过高的问题。